### PR TITLE
[feat] 설문조사 뷰 API 연동

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -99,6 +99,7 @@ dependencies {
     implementation("com.squareup.retrofit2:retrofit:$retrofit_version")
     implementation("com.squareup.retrofit2:converter-gson:$retrofit_version")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.5.0")
     implementation("com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:1.0.0")
 
     // okhttp3

--- a/app/src/main/java/com/example/teacherforboss/data/datasource/remote/MembersRemoteDataSource.kt
+++ b/app/src/main/java/com/example/teacherforboss/data/datasource/remote/MembersRemoteDataSource.kt
@@ -1,0 +1,9 @@
+package com.example.teacherforboss.data.datasource.remote
+
+import com.example.teacherforboss.data.model.request.RequestSurveyDto
+import com.example.teacherforboss.data.model.response.ResponseSurveyDto
+import com.example.teacherforboss.util.base.BaseResponse
+
+interface MembersRemoteDataSource {
+    suspend fun postSurveyResult(requestSurveyDto: RequestSurveyDto): BaseResponse<ResponseSurveyDto>
+}

--- a/app/src/main/java/com/example/teacherforboss/data/datasource/remote/SurveyRemoteDataSource.kt
+++ b/app/src/main/java/com/example/teacherforboss/data/datasource/remote/SurveyRemoteDataSource.kt
@@ -1,4 +1,0 @@
-package com.example.teacherforboss.data.datasource.remote
-
-interface SurveyRemoteDataSource {
-}

--- a/app/src/main/java/com/example/teacherforboss/data/datasourceimpl/remote/MembersRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/example/teacherforboss/data/datasourceimpl/remote/MembersRemoteDataSourceImpl.kt
@@ -1,0 +1,15 @@
+package com.example.teacherforboss.data.datasourceimpl.remote
+
+import com.example.teacherforboss.data.datasource.remote.MembersRemoteDataSource
+import com.example.teacherforboss.data.model.request.RequestSurveyDto
+import com.example.teacherforboss.data.model.response.ResponseSurveyDto
+import com.example.teacherforboss.data.service.MembersService
+import com.example.teacherforboss.util.base.BaseResponse
+import javax.inject.Inject
+
+class MembersRemoteDataSourceImpl @Inject constructor(
+    private val membersService: MembersService
+) : MembersRemoteDataSource {
+    override suspend fun postSurveyResult(requestSurveyDto: RequestSurveyDto): BaseResponse<ResponseSurveyDto> =
+        membersService.postSurveyResult(request = requestSurveyDto)
+}

--- a/app/src/main/java/com/example/teacherforboss/data/datasourceimpl/remote/SurveyRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/example/teacherforboss/data/datasourceimpl/remote/SurveyRemoteDataSourceImpl.kt
@@ -1,4 +1,0 @@
-package com.example.teacherforboss.data.datasourceimpl.remote
-
-class SurveyRemoteDataSourceImpl {
-}

--- a/app/src/main/java/com/example/teacherforboss/data/mapper/SurveyEntityMapper.kt
+++ b/app/src/main/java/com/example/teacherforboss/data/mapper/SurveyEntityMapper.kt
@@ -1,1 +1,11 @@
 package com.example.teacherforboss.data.mapper
+
+import com.example.teacherforboss.data.model.request.RequestSurveyDto
+import com.example.teacherforboss.domain.model.SurveyEntity
+
+fun SurveyEntity.toRequestSurveyDto() = RequestSurveyDto(
+    question1 = this.question1,
+    question2 = this.question2,
+    question3 = this.question3,
+    question4 = this.question4
+)

--- a/app/src/main/java/com/example/teacherforboss/data/model/request/RequestSurveyDto.kt
+++ b/app/src/main/java/com/example/teacherforboss/data/model/request/RequestSurveyDto.kt
@@ -6,5 +6,11 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class RequestSurveyDto(
     @SerialName("question1")
-    val question1: Long
+    val question1: Int,
+    @SerialName("question2")
+    val question2: List<Int>,
+    @SerialName("question3")
+    val question3: Int,
+    @SerialName("question4")
+    val question4: String
 )

--- a/app/src/main/java/com/example/teacherforboss/data/model/response/ResponseSurveyDto.kt
+++ b/app/src/main/java/com/example/teacherforboss/data/model/response/ResponseSurveyDto.kt
@@ -1,10 +1,19 @@
 package com.example.teacherforboss.data.model.response
 
+import com.example.teacherforboss.domain.model.SurveyResultEntity
+import kotlinx.datetime.LocalDateTime
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class ResponseSurveyDto(
     @SerialName("surveyId")
-    val surveyId: Long
-)
+    val surveyId: Long,
+    @SerialName("createdAt")
+    val createdAt: LocalDateTime,
+) {
+    fun toSurveyResultEntity() = SurveyResultEntity(
+        surveyId = surveyId,
+        createdAt = createdAt.toString()
+    )
+}

--- a/app/src/main/java/com/example/teacherforboss/data/repository/MembersRepositoryImpl.kt
+++ b/app/src/main/java/com/example/teacherforboss/data/repository/MembersRepositoryImpl.kt
@@ -1,0 +1,23 @@
+package com.example.teacherforboss.data.repository
+
+import com.example.teacherforboss.data.datasource.remote.MembersRemoteDataSource
+import com.example.teacherforboss.data.mapper.toRequestSurveyDto
+import com.example.teacherforboss.domain.model.SurveyEntity
+import com.example.teacherforboss.domain.model.SurveyResultEntity
+import com.example.teacherforboss.domain.repository.MembersRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class MembersRepositoryImpl @Inject constructor(
+    private val membersRemoteDataSource: MembersRemoteDataSource,
+) : MembersRepository {
+    override suspend fun postSurveyResult(surveyEntity: SurveyEntity): Flow<SurveyResultEntity> = flow {
+        val data = runCatching {
+            membersRemoteDataSource.postSurveyResult(
+                requestSurveyDto = surveyEntity.toRequestSurveyDto(),
+            ).result.toSurveyResultEntity()
+        }
+        emit(data.getOrThrow())
+    }
+}

--- a/app/src/main/java/com/example/teacherforboss/data/repository/SurveyRepositoryImpl.kt
+++ b/app/src/main/java/com/example/teacherforboss/data/repository/SurveyRepositoryImpl.kt
@@ -1,4 +1,0 @@
-package com.example.teacherforboss.data.repository
-
-class SurveyRepositoryImpl {
-}

--- a/app/src/main/java/com/example/teacherforboss/data/service/MembersService.kt
+++ b/app/src/main/java/com/example/teacherforboss/data/service/MembersService.kt
@@ -2,12 +2,18 @@ package com.example.teacherforboss.data.service
 
 import com.example.teacherforboss.data.model.request.RequestSurveyDto
 import com.example.teacherforboss.data.model.response.ResponseSurveyDto
+import com.example.teacherforboss.util.base.BaseResponse
 import retrofit2.http.Body
 import retrofit2.http.POST
 
-interface SurveyService {
-    @POST("signup/surveyForClass")
+interface MembersService {
+    @POST("$MEMBERS/$SURVEY")
     suspend fun postSurveyResult(
         @Body request: RequestSurveyDto
-    ): ResponseSurveyDto
+    ): BaseResponse<ResponseSurveyDto>
+
+    companion object {
+        const val MEMBERS = "members"
+        const val SURVEY = "survey"
+    }
 }

--- a/app/src/main/java/com/example/teacherforboss/di/DataSourceModule.kt
+++ b/app/src/main/java/com/example/teacherforboss/di/DataSourceModule.kt
@@ -1,11 +1,17 @@
 package com.example.teacherforboss.di
 
+import com.example.teacherforboss.data.datasource.remote.MembersRemoteDataSource
+import com.example.teacherforboss.data.datasourceimpl.remote.MembersRemoteDataSourceImpl
+import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-abstract class DataSourceModule{
-
+abstract class DataSourceModule {
+    @Binds
+    @Singleton
+    abstract fun bindsMembersRemoteDataSource(membersRemoteDataSourceImpl: MembersRemoteDataSourceImpl): MembersRemoteDataSource
 }

--- a/app/src/main/java/com/example/teacherforboss/di/RepositoryModule.kt
+++ b/app/src/main/java/com/example/teacherforboss/di/RepositoryModule.kt
@@ -1,10 +1,17 @@
 package com.example.teacherforboss.di
 
+import com.example.teacherforboss.data.repository.MembersRepositoryImpl
+import com.example.teacherforboss.domain.repository.MembersRepository
+import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
 abstract class RepositoryModule {
+    @Binds
+    @Singleton
+    abstract fun bindsMembersRepository(membersRepositoryImpl: MembersRepositoryImpl): MembersRepository
 }

--- a/app/src/main/java/com/example/teacherforboss/di/RetrofitModule.kt
+++ b/app/src/main/java/com/example/teacherforboss/di/RetrofitModule.kt
@@ -1,11 +1,23 @@
 package com.example.teacherforboss.di
 
+import com.example.teacherforboss.BuildConfig
+import com.example.teacherforboss.BuildConfig.DEBUG
+import com.example.teacherforboss.data.intercepter.AuthInterceptor
+import com.example.teacherforboss.di.qualifier.Auth
+import com.example.teacherforboss.di.qualifier.TeacherForBoss
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
 @Module
@@ -21,5 +33,43 @@ object RetrofitModule {
         ignoreUnknownKeys = true
     }
 
-    // TODO 추가 예정
+    @Provides
+    @Singleton
+    fun providesOkHttpClient(
+        loggingInterceptor: HttpLoggingInterceptor,
+        @Auth authInterceptor: Interceptor,
+    ): OkHttpClient =
+        OkHttpClient.Builder().apply {
+            OkHttpClient.Builder().apply {
+                connectTimeout(10, TimeUnit.SECONDS)
+                writeTimeout(10, TimeUnit.SECONDS)
+                readTimeout(10, TimeUnit.SECONDS)
+                addInterceptor(authInterceptor)
+                if (DEBUG) addInterceptor(loggingInterceptor)
+            }
+        }.build()
+
+    @Provides
+    @Singleton
+    fun providesLogginInterceptor(): HttpLoggingInterceptor = HttpLoggingInterceptor().apply {
+        level = HttpLoggingInterceptor.Level.BODY
+    }
+
+    @Provides
+    @Singleton
+    @Auth
+    fun provideAuthInterceptor(interceptor: AuthInterceptor): Interceptor = interceptor
+
+    @ExperimentalSerializationApi
+    @Provides
+    @TeacherForBoss
+    @Singleton
+    fun providesTeacherForBossRetrofit(okHttpClient: OkHttpClient, json: Json): Retrofit =
+        Retrofit.Builder()
+            .baseUrl(BuildConfig.BASE_URL)
+            .client(okHttpClient)
+            .addConverterFactory(
+                json.asConverterFactory(requireNotNull("application/json".toMediaTypeOrNull())),
+            )
+            .build()
 }

--- a/app/src/main/java/com/example/teacherforboss/di/ServiceModule.kt
+++ b/app/src/main/java/com/example/teacherforboss/di/ServiceModule.kt
@@ -1,10 +1,19 @@
 package com.example.teacherforboss.di
 
+import com.example.teacherforboss.data.service.MembersService
+import com.example.teacherforboss.di.qualifier.TeacherForBoss
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
 object ServiceModule {
+    @Provides
+    @Singleton
+    fun providesMembersService(@TeacherForBoss retrofit: Retrofit): MembersService =
+        retrofit.create(MembersService::class.java)
 }

--- a/app/src/main/java/com/example/teacherforboss/di/UseCaseModule.kt
+++ b/app/src/main/java/com/example/teacherforboss/di/UseCaseModule.kt
@@ -1,10 +1,18 @@
 package com.example.teacherforboss.di
 
+import com.example.teacherforboss.domain.repository.MembersRepository
+import com.example.teacherforboss.domain.usecase.PostSurveyUseCase
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
 class UseCaseModule {
+    @Provides
+    @Singleton
+    fun providesPostSurveyUseCase(membersRepository: MembersRepository): PostSurveyUseCase =
+        PostSurveyUseCase(membersRepository = membersRepository)
 }

--- a/app/src/main/java/com/example/teacherforboss/di/qualifier/Qualifier.kt
+++ b/app/src/main/java/com/example/teacherforboss/di/qualifier/Qualifier.kt
@@ -1,0 +1,10 @@
+package com.example.teacherforboss.di.qualifier
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class TeacherForBoss
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class Auth

--- a/app/src/main/java/com/example/teacherforboss/domain/model/SurveyEntity.kt
+++ b/app/src/main/java/com/example/teacherforboss/domain/model/SurveyEntity.kt
@@ -1,6 +1,8 @@
 package com.example.teacherforboss.domain.model
 
 data class SurveyEntity(
-    val question1: Long,
-    val question2: Long
+    val question1: Int,
+    val question2: ArrayList<Int>,
+    val question3: Int,
+    val question4: String
 )

--- a/app/src/main/java/com/example/teacherforboss/domain/model/SurveyResultEntity.kt
+++ b/app/src/main/java/com/example/teacherforboss/domain/model/SurveyResultEntity.kt
@@ -1,0 +1,6 @@
+package com.example.teacherforboss.domain.model
+
+data class SurveyResultEntity(
+    val surveyId: Long,
+    val createdAt: String,
+)

--- a/app/src/main/java/com/example/teacherforboss/domain/repository/MembersRepository.kt
+++ b/app/src/main/java/com/example/teacherforboss/domain/repository/MembersRepository.kt
@@ -1,0 +1,9 @@
+package com.example.teacherforboss.domain.repository
+
+import com.example.teacherforboss.domain.model.SurveyEntity
+import com.example.teacherforboss.domain.model.SurveyResultEntity
+import kotlinx.coroutines.flow.Flow
+
+interface MembersRepository {
+    suspend fun postSurveyResult(surveyEntity: SurveyEntity): Flow<SurveyResultEntity>
+}

--- a/app/src/main/java/com/example/teacherforboss/domain/repository/SurveyRepository.kt
+++ b/app/src/main/java/com/example/teacherforboss/domain/repository/SurveyRepository.kt
@@ -1,5 +1,0 @@
-package com.example.teacherforboss.domain.repository
-
-interface SurveyRepository {
-    suspend fun postSurveyResult(): Unit?
-}

--- a/app/src/main/java/com/example/teacherforboss/domain/usecase/PostSurveyResultUseCase.kt
+++ b/app/src/main/java/com/example/teacherforboss/domain/usecase/PostSurveyResultUseCase.kt
@@ -1,8 +1,0 @@
-package com.example.teacherforboss.domain.usecase
-
-import com.example.teacherforboss.domain.repository.SurveyRepository
-
-class PostSurveyResultUseCase (
-    private val surveyRepository: SurveyRepository
-){
-}

--- a/app/src/main/java/com/example/teacherforboss/domain/usecase/PostSurveyUseCase.kt
+++ b/app/src/main/java/com/example/teacherforboss/domain/usecase/PostSurveyUseCase.kt
@@ -1,0 +1,15 @@
+package com.example.teacherforboss.domain.usecase
+
+import com.example.teacherforboss.domain.model.SurveyEntity
+import com.example.teacherforboss.domain.model.SurveyResultEntity
+import com.example.teacherforboss.domain.repository.MembersRepository
+import kotlinx.coroutines.flow.Flow
+
+class PostSurveyUseCase (
+    private val membersRepository: MembersRepository
+){
+    suspend operator fun invoke(surveyEntity: SurveyEntity): Flow<SurveyResultEntity> =
+        membersRepository.postSurveyResult(
+            surveyEntity = surveyEntity
+        )
+}

--- a/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/SurveyActivity.kt
+++ b/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/SurveyActivity.kt
@@ -17,9 +17,11 @@ import com.example.teacherforboss.presentation.ui.survey.question.SurveyProblemF
 import com.example.teacherforboss.presentation.ui.survey.question.SurveyProblemReasonFragment
 import com.example.teacherforboss.presentation.ui.survey.question.SurveyStudyFragment
 import com.example.teacherforboss.util.base.BindingActivity
+import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
+@AndroidEntryPoint
 class SurveyActivity :
     BindingActivity<ActivitySurveyBinding>(R.layout.activity_survey) {
     private val surveyViewModel: SurveyViewModel by viewModels()
@@ -53,7 +55,7 @@ class SurveyActivity :
             when (binding.vpSurvey.currentItem) {
                 fragmentList.size - 1 -> {
                     navigateToMain()
-                    // TODO 서버통신
+                    surveyViewModel.postSurveyResult()
                 }
 
                 else -> binding.vpSurvey.currentItem++

--- a/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/SurveyViewModel.kt
+++ b/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/SurveyViewModel.kt
@@ -2,16 +2,29 @@ package com.example.teacherforboss.presentation.ui.survey
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.teacherforboss.domain.model.SurveyEntity
+import com.example.teacherforboss.domain.model.SurveyResultEntity
+import com.example.teacherforboss.domain.usecase.PostSurveyUseCase
 import com.example.teacherforboss.presentation.type.SurveyType
 import com.example.teacherforboss.util.combineAll
+import com.example.teacherforboss.util.view.UiState
+import dagger.hilt.android.AndroidEntryPoint
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-class SurveyViewModel : ViewModel() {
+@HiltViewModel
+class SurveyViewModel @Inject constructor(
+    private val postSurveyUseCase: PostSurveyUseCase
+) : ViewModel() {
     private val _currentPage = MutableStateFlow(FIRST_FRAGMENT_POSITION)
     val currentPage get() = _currentPage.asStateFlow()
 
@@ -25,6 +38,9 @@ class SurveyViewModel : ViewModel() {
     val selectedProblem get() = _selectedProblem.asStateFlow()
 
     val problemDescription = MutableStateFlow("")
+
+    private val _surveyResultState = MutableSharedFlow<UiState<SurveyResultEntity>>()
+    val surveyResultState get() = _surveyResultState.asSharedFlow()
 
     val surveyBtnEnabled: StateFlow<Boolean> = listOf(
         currentPage,
@@ -68,6 +84,25 @@ class SurveyViewModel : ViewModel() {
         _selectedProblem.value = answer
     }
 
+    fun postSurveyResult() {
+        viewModelScope.launch {
+            _surveyResultState.emit(UiState.Loading)
+            runCatching {
+                postSurveyUseCase(
+                    surveyEntity = SurveyEntity(
+                        question1 = selectedJob.value,
+                        question2 = selectedStudy.value,
+                        question3 = selectedProblem.value,
+                        question4 = problemDescription.value
+                    )
+                ).collect(){data ->
+                    _surveyResultState.emit(UiState.Success(data))
+                }
+            }.onFailure { exception: Throwable ->
+                _surveyResultState.emit(UiState.Error(exception.message))
+            }
+        }
+    }
     companion object {
         private const val FIRST_FRAGMENT_POSITION = 0
         private const val DEFAULT_SELECTED_NUMBER = 0

--- a/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/question/SurveyCompleteFragment.kt
+++ b/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/question/SurveyCompleteFragment.kt
@@ -5,7 +5,9 @@ import android.view.View
 import com.example.teacherforboss.R
 import com.example.teacherforboss.databinding.FragmentSurveyCompleteBinding
 import com.example.teacherforboss.util.base.BindingFragment
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class SurveyCompleteFragment :
     BindingFragment<FragmentSurveyCompleteBinding>(R.layout.fragment_survey_complete) {
 

--- a/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/question/SurveyJobFragment.kt
+++ b/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/question/SurveyJobFragment.kt
@@ -9,7 +9,9 @@ import com.example.teacherforboss.R
 import com.example.teacherforboss.databinding.FragmentSurveyJobBinding
 import com.example.teacherforboss.presentation.ui.survey.SurveyViewModel
 import com.example.teacherforboss.util.base.BindingFragment
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class SurveyJobFragment :
     BindingFragment<FragmentSurveyJobBinding>(R.layout.fragment_survey_job) {
     private val viewModel by activityViewModels<SurveyViewModel>()

--- a/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/question/SurveyProblemFragment.kt
+++ b/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/question/SurveyProblemFragment.kt
@@ -9,7 +9,9 @@ import com.example.teacherforboss.R
 import com.example.teacherforboss.databinding.FragmentSurveyProblemBinding
 import com.example.teacherforboss.presentation.ui.survey.SurveyViewModel
 import com.example.teacherforboss.util.base.BindingFragment
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class SurveyProblemFragment :
     BindingFragment<FragmentSurveyProblemBinding>(R.layout.fragment_survey_problem) {
     private val viewModel by activityViewModels<SurveyViewModel>()

--- a/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/question/SurveyProblemReasonFragment.kt
+++ b/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/question/SurveyProblemReasonFragment.kt
@@ -11,9 +11,11 @@ import com.example.teacherforboss.databinding.FragmentSurveyProblemReasonBinding
 import com.example.teacherforboss.presentation.ui.survey.SurveyViewModel
 import com.example.teacherforboss.util.base.BindingFragment
 import com.example.teacherforboss.util.context.hideKeyboard
+import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
+@AndroidEntryPoint
 class SurveyProblemReasonFragment :
     BindingFragment<FragmentSurveyProblemReasonBinding>(R.layout.fragment_survey_problem_reason) {
     private val viewModel by activityViewModels<SurveyViewModel>()

--- a/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/question/SurveyStudyFragment.kt
+++ b/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/question/SurveyStudyFragment.kt
@@ -9,7 +9,9 @@ import com.example.teacherforboss.R
 import com.example.teacherforboss.databinding.FragmentSurveyStudyBinding
 import com.example.teacherforboss.presentation.ui.survey.SurveyViewModel
 import com.example.teacherforboss.util.base.BindingFragment
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class SurveyStudyFragment :
     BindingFragment<FragmentSurveyStudyBinding>(R.layout.fragment_survey_study) {
     private val viewModel by activityViewModels<SurveyViewModel>()


### PR DESCRIPTION
## Related issue 🛠
- closed #11 

## Work Description ✏️
- 설문조사 API 클린아키텍처 적용
- di module 구현 
- /members/survey API 연동

## Screenshot 📸
생략

## Uncompleted Tasks 😅
- [ ] accessToken 발급 문제 해결 후 API 연동 잘 됐는지 테스트
- [ ] 설문조사 2번 문항 실시간 버튼 활성화(flow combine에 arraylist 결합 방법 찾아보기)

## To Reviewers 📢
중간 피알 올립니다! 참고하셔서 api 구현하시면 좋을 것 같습니둥..