### PR TITLE
[fix] 설문조사 뷰 사용자명 버그와 버튼 실시간 갱신 문제 해결

### DIFF
--- a/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/SurveyActivity.kt
+++ b/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/SurveyActivity.kt
@@ -133,6 +133,7 @@ class SurveyActivity :
                 navigateToPreviousFragment()
             }
         }
+        onBackPressedDispatcher.addCallback(this, onBackPressed)
     }
 
     companion object {

--- a/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/SurveyActivity.kt
+++ b/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/SurveyActivity.kt
@@ -17,11 +17,10 @@ import com.example.teacherforboss.presentation.ui.survey.question.SurveyProblemF
 import com.example.teacherforboss.presentation.ui.survey.question.SurveyProblemReasonFragment
 import com.example.teacherforboss.presentation.ui.survey.question.SurveyStudyFragment
 import com.example.teacherforboss.util.base.BindingActivity
-import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
-//@AndroidEntryPoint
+// @AndroidEntryPoint
 class SurveyActivity :
     BindingActivity<ActivitySurveyBinding>(R.layout.activity_survey) {
     private val surveyViewModel: SurveyViewModel by viewModels()
@@ -37,6 +36,7 @@ class SurveyActivity :
         initLayout()
         addListeners()
         collectData()
+        onBackPressedBtn()
     }
 
     private fun initLayout() {
@@ -124,6 +124,14 @@ class SurveyActivity :
         Intent(this, MainActivity::class.java).apply {
             startActivity(this)
             finish()
+        }
+    }
+
+    private fun onBackPressedBtn() {
+        onBackPressed = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                navigateToPreviousFragment()
+            }
         }
     }
 

--- a/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/SurveyStartActivity.kt
+++ b/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/SurveyStartActivity.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import androidx.activity.OnBackPressedCallback
 import com.example.teacherforboss.R
 import com.example.teacherforboss.databinding.ActivitySurveyStartBinding
-import com.example.teacherforboss.presentation.ui.auth.login.LoginActivity
 import com.example.teacherforboss.presentation.ui.main.MainActivity
 import com.example.teacherforboss.util.base.BindingActivity
 

--- a/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/SurveyStartActivity.kt
+++ b/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/SurveyStartActivity.kt
@@ -23,7 +23,8 @@ class SurveyStartActivity :
 
     private fun initLayout() {
         // TODO 로그인 시 저장되는 사용자 이름 쉐프에서 가져와 출력
-        String.format(resources.getString(R.string.survey_start_name), "김빛나")
+        var text = getString(R.string.survey_start_name, "하지은")
+        binding.surveyStartWelcomeName.text = text
     }
 
     private fun addListeners() {

--- a/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/SurveyStartActivity.kt
+++ b/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/SurveyStartActivity.kt
@@ -2,18 +2,23 @@ package com.example.teacherforboss.presentation.ui.survey
 
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.OnBackPressedCallback
 import com.example.teacherforboss.R
 import com.example.teacherforboss.databinding.ActivitySurveyStartBinding
 import com.example.teacherforboss.presentation.ui.auth.login.LoginActivity
+import com.example.teacherforboss.presentation.ui.main.MainActivity
 import com.example.teacherforboss.util.base.BindingActivity
 
 class SurveyStartActivity :
     BindingActivity<ActivitySurveyStartBinding>(R.layout.activity_survey_start) {
+    private lateinit var onBackPressed: OnBackPressedCallback
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         initLayout()
         addListeners()
+        onBackPressedBtn()
     }
 
     private fun initLayout() {
@@ -23,7 +28,7 @@ class SurveyStartActivity :
 
     private fun addListeners() {
         binding.layoutSurveyStartBtn.setOnClickListener { navigateToSurvey() }
-        binding.ivSurveyStartBackBtn.setOnClickListener { navigateToLogin() }
+        binding.ivSurveyStartBackBtn.setOnClickListener { navigateToMain() }
     }
 
     private fun navigateToSurvey() {
@@ -33,10 +38,18 @@ class SurveyStartActivity :
         }
     }
 
-    private fun navigateToLogin() {
-        Intent(this, LoginActivity::class.java).apply {
+    private fun navigateToMain() {
+        Intent(this, MainActivity::class.java).apply {
             startActivity(this)
             finish()
+        }
+    }
+
+    private fun onBackPressedBtn() {
+        onBackPressed = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                navigateToMain()
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/SurveyStartActivity.kt
+++ b/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/SurveyStartActivity.kt
@@ -51,5 +51,6 @@ class SurveyStartActivity :
                 navigateToMain()
             }
         }
+        onBackPressedDispatcher.addCallback(this, onBackPressed)
     }
 }

--- a/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/SurveyViewModel.kt
+++ b/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/SurveyViewModel.kt
@@ -69,6 +69,7 @@ class SurveyViewModel(
 
     fun setSelectedStudy(answer: Int) {
         _selectedStudy.value.add(answer)
+        setSelectedStudySize()
     }
 
     fun setSelectedStudySize() {

--- a/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/SurveyViewModel.kt
+++ b/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/SurveyViewModel.kt
@@ -2,14 +2,10 @@ package com.example.teacherforboss.presentation.ui.survey
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.teacherforboss.domain.model.SurveyEntity
 import com.example.teacherforboss.domain.model.SurveyResultEntity
-import com.example.teacherforboss.domain.usecase.PostSurveyUseCase
 import com.example.teacherforboss.presentation.type.SurveyType
 import com.example.teacherforboss.util.combineAll
 import com.example.teacherforboss.util.view.UiState
-import dagger.hilt.android.AndroidEntryPoint
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -18,10 +14,8 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-//@HiltViewModel
+// @HiltViewModel
 class SurveyViewModel(
 //    private val postSurveyUseCase: PostSurveyUseCase
 ) : ViewModel() {
@@ -92,7 +86,7 @@ class SurveyViewModel(
         setSelectedStudySize()
     }
 
-//    fun postSurveyResult() {
+    //    fun postSurveyResult() {
 //        viewModelScope.launch {
 //            _surveyResultState.emit(UiState.Loading)
 //            runCatching {

--- a/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/question/SurveyCompleteFragment.kt
+++ b/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/question/SurveyCompleteFragment.kt
@@ -5,9 +5,8 @@ import android.view.View
 import com.example.teacherforboss.R
 import com.example.teacherforboss.databinding.FragmentSurveyCompleteBinding
 import com.example.teacherforboss.util.base.BindingFragment
-import dagger.hilt.android.AndroidEntryPoint
 
-//@AndroidEntryPoint
+// @AndroidEntryPoint
 class SurveyCompleteFragment :
     BindingFragment<FragmentSurveyCompleteBinding>(R.layout.fragment_survey_complete) {
 

--- a/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/question/SurveyJobFragment.kt
+++ b/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/question/SurveyJobFragment.kt
@@ -9,9 +9,8 @@ import com.example.teacherforboss.R
 import com.example.teacherforboss.databinding.FragmentSurveyJobBinding
 import com.example.teacherforboss.presentation.ui.survey.SurveyViewModel
 import com.example.teacherforboss.util.base.BindingFragment
-import dagger.hilt.android.AndroidEntryPoint
 
-//@AndroidEntryPoint
+// @AndroidEntryPoint
 class SurveyJobFragment :
     BindingFragment<FragmentSurveyJobBinding>(R.layout.fragment_survey_job) {
     private val viewModel by activityViewModels<SurveyViewModel>()

--- a/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/question/SurveyProblemFragment.kt
+++ b/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/question/SurveyProblemFragment.kt
@@ -9,9 +9,8 @@ import com.example.teacherforboss.R
 import com.example.teacherforboss.databinding.FragmentSurveyProblemBinding
 import com.example.teacherforboss.presentation.ui.survey.SurveyViewModel
 import com.example.teacherforboss.util.base.BindingFragment
-import dagger.hilt.android.AndroidEntryPoint
 
-//@AndroidEntryPoint
+// @AndroidEntryPoint
 class SurveyProblemFragment :
     BindingFragment<FragmentSurveyProblemBinding>(R.layout.fragment_survey_problem) {
     private val viewModel by activityViewModels<SurveyViewModel>()
@@ -27,10 +26,25 @@ class SurveyProblemFragment :
     private fun addListeners() {
         binding.rgSurveyProblem.setOnCheckedChangeListener { group, checkedId ->
             when (checkedId) {
-                R.id.btn_survey_problem_well_known -> setRadioCheckedProblem(binding.btnSurveyProblemWellKnown, 1)
-                R.id.btn_survey_problem_known -> setRadioCheckedProblem(binding.btnSurveyProblemKnown, 2)
-                R.id.btn_survey_problem_unknown -> setRadioCheckedProblem(binding.btnSurveyProblemUnknown, 3)
-                R.id.btn_survey_problem_anything -> setRadioCheckedProblem(binding.btnSurveyProblemAnything, 4)
+                R.id.btn_survey_problem_well_known -> setRadioCheckedProblem(
+                    binding.btnSurveyProblemWellKnown,
+                    1,
+                )
+
+                R.id.btn_survey_problem_known -> setRadioCheckedProblem(
+                    binding.btnSurveyProblemKnown,
+                    2,
+                )
+
+                R.id.btn_survey_problem_unknown -> setRadioCheckedProblem(
+                    binding.btnSurveyProblemUnknown,
+                    3,
+                )
+
+                R.id.btn_survey_problem_anything -> setRadioCheckedProblem(
+                    binding.btnSurveyProblemAnything,
+                    4,
+                )
             }
         }
 

--- a/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/question/SurveyProblemReasonFragment.kt
+++ b/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/question/SurveyProblemReasonFragment.kt
@@ -11,11 +11,10 @@ import com.example.teacherforboss.databinding.FragmentSurveyProblemReasonBinding
 import com.example.teacherforboss.presentation.ui.survey.SurveyViewModel
 import com.example.teacherforboss.util.base.BindingFragment
 import com.example.teacherforboss.util.context.hideKeyboard
-import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
-//@AndroidEntryPoint
+// @AndroidEntryPoint
 class SurveyProblemReasonFragment :
     BindingFragment<FragmentSurveyProblemReasonBinding>(R.layout.fragment_survey_problem_reason) {
     private val viewModel by activityViewModels<SurveyViewModel>()

--- a/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/question/SurveyStudyFragment.kt
+++ b/app/src/main/java/com/example/teacherforboss/presentation/ui/survey/question/SurveyStudyFragment.kt
@@ -9,9 +9,8 @@ import com.example.teacherforboss.R
 import com.example.teacherforboss.databinding.FragmentSurveyStudyBinding
 import com.example.teacherforboss.presentation.ui.survey.SurveyViewModel
 import com.example.teacherforboss.util.base.BindingFragment
-import dagger.hilt.android.AndroidEntryPoint
 
-//@AndroidEntryPoint
+// @AndroidEntryPoint
 class SurveyStudyFragment :
     BindingFragment<FragmentSurveyStudyBinding>(R.layout.fragment_survey_study) {
     private val viewModel by activityViewModels<SurveyViewModel>()


### PR DESCRIPTION
## Related issue 🛠
- closed #27 

## Work Description ✏️
- 설문조사 뷰 : 데모데이용 이름 뷰에 박아둠
- 설문조사 뷰 : 2번 문항 실시간 갱신 안되는 문제 해결
- 안드로이드 이전 버튼 기능 추가
    - 설문조사 시작 뷰 : MainActivity로 이동(ivBackBtn도 MainActivity로 이동하도록 수정)
    - 설문조사 뷰 : < 버튼과 동일하게 작동하도록 구현
- 전체적인 정렬 적용

## Screenshot 📸
생략

## Uncompleted Tasks 😅
- [ ]  설문조사 뷰 : 가입 시 SharedPreferences에 저장된 사용자명 출력

## To Reviewers 📢
SharedPreferences에 로그인 유저 정보가 제대로 저장되어 있지 않는 것 같아서 이 부분 해결하면
쉐프에 저장된 사용자명 뷰에 띄우는 걸로 할게욥 >)<