### PR TITLE
[feat] 시험보기 뷰 Spannable 구현 및 안드로이드 자체 뒤로가기 버튼 기능 구현

### DIFF
--- a/app/src/main/java/com/example/teacherforboss/presentation/ui/exam/ExamActivity.kt
+++ b/app/src/main/java/com/example/teacherforboss/presentation/ui/exam/ExamActivity.kt
@@ -2,6 +2,7 @@ package com.example.teacherforboss.presentation.ui.exam
 
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.flowWithLifecycle
@@ -22,6 +23,7 @@ import kotlinx.coroutines.flow.onEach
 class ExamActivity : BindingActivity<ActivityExamBinding>(R.layout.activity_exam) {
     private val examViewModel: ExamViewModel by viewModels()
     private lateinit var fragmentList: ArrayList<Fragment>
+    private lateinit var onBackPressed: OnBackPressedCallback
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -32,6 +34,7 @@ class ExamActivity : BindingActivity<ActivityExamBinding>(R.layout.activity_exam
         initLayout()
         addListeners()
         collectData()
+        onBackPressedBtn()
     }
 
     private fun initLayout() {
@@ -120,6 +123,15 @@ class ExamActivity : BindingActivity<ActivityExamBinding>(R.layout.activity_exam
             startActivity(this)
             finish()
         }
+    }
+
+    private fun onBackPressedBtn() {
+        onBackPressed = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                navigateToPreviousFragment()
+            }
+        }
+        onBackPressedDispatcher.addCallback(this, onBackPressed)
     }
 
     companion object {

--- a/app/src/main/java/com/example/teacherforboss/presentation/ui/exam/ExamActivity.kt
+++ b/app/src/main/java/com/example/teacherforboss/presentation/ui/exam/ExamActivity.kt
@@ -15,7 +15,6 @@ import com.example.teacherforboss.presentation.ui.exam.question.ExamFourthFragme
 import com.example.teacherforboss.presentation.ui.exam.question.ExamSecondFragment
 import com.example.teacherforboss.presentation.ui.exam.question.ExamThirdFragment
 import com.example.teacherforboss.presentation.ui.examResult.examResultActivity
-import com.example.teacherforboss.presentation.ui.main.MainActivity
 import com.example.teacherforboss.util.base.BindingActivity
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach

--- a/app/src/main/java/com/example/teacherforboss/presentation/ui/exam/ExamFragmentStateAdapter.kt
+++ b/app/src/main/java/com/example/teacherforboss/presentation/ui/exam/ExamFragmentStateAdapter.kt
@@ -4,7 +4,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.viewpager2.adapter.FragmentStateAdapter
 
-class ExamFragmentStateAdapter (
+class ExamFragmentStateAdapter(
     private val fragmentList: ArrayList<Fragment>,
     fragmentActivity: FragmentActivity,
 ) : FragmentStateAdapter(fragmentActivity) {

--- a/app/src/main/java/com/example/teacherforboss/presentation/ui/exam/ExamStartActivity.kt
+++ b/app/src/main/java/com/example/teacherforboss/presentation/ui/exam/ExamStartActivity.kt
@@ -3,16 +3,20 @@ package com.example.teacherforboss.presentation.ui.exam
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.activity.OnBackPressedCallback
 import com.example.teacherforboss.R
 import com.example.teacherforboss.databinding.ActivityExamStartBinding
 import com.example.teacherforboss.presentation.ui.main.MainActivity
 import com.example.teacherforboss.util.base.BindingActivity
 
 class ExamStartActivity : BindingActivity<ActivityExamStartBinding>(R.layout.activity_exam_start) {
+    private lateinit var onBackPressed: OnBackPressedCallback
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         addListeners()
+        onBackPressedBtn()
     }
 
     private fun addListeners(){
@@ -32,5 +36,14 @@ class ExamStartActivity : BindingActivity<ActivityExamStartBinding>(R.layout.act
             startActivity(this)
             finish()
         }
+    }
+
+    private fun onBackPressedBtn() {
+        onBackPressed = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                navigateToHome()
+            }
+        }
+        onBackPressedDispatcher.addCallback(this, onBackPressed)
     }
 }

--- a/app/src/main/java/com/example/teacherforboss/presentation/ui/exam/ExamStartActivity.kt
+++ b/app/src/main/java/com/example/teacherforboss/presentation/ui/exam/ExamStartActivity.kt
@@ -3,7 +3,12 @@ package com.example.teacherforboss.presentation.ui.exam
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.text.Spannable
+import android.text.SpannableString
+import android.text.style.ForegroundColorSpan
+import android.text.style.TextAppearanceSpan
 import androidx.activity.OnBackPressedCallback
+import androidx.core.content.ContextCompat
 import com.example.teacherforboss.R
 import com.example.teacherforboss.databinding.ActivityExamStartBinding
 import com.example.teacherforboss.presentation.ui.main.MainActivity
@@ -15,8 +20,27 @@ class ExamStartActivity : BindingActivity<ActivityExamStartBinding>(R.layout.act
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        initLayout()
         addListeners()
         onBackPressedBtn()
+    }
+
+    private fun initLayout() {
+        binding.examStartWelcomeName.text = SpannableString(
+            getString(R.string.exam_start_title)
+        ).apply {
+            setSpan(
+                ForegroundColorSpan(
+                    ContextCompat.getColor(
+                        this@ExamStartActivity,
+                        R.color.main_purple_00
+                    )
+                ),
+                SERVICE_START,
+                SERVICE_END,
+                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+            )
+        }
     }
 
     private fun addListeners(){
@@ -45,5 +69,10 @@ class ExamStartActivity : BindingActivity<ActivityExamStartBinding>(R.layout.act
             }
         }
         onBackPressedDispatcher.addCallback(this, onBackPressed)
+    }
+
+    companion object {
+        const val SERVICE_START = 4
+        const val SERVICE_END = 7
     }
 }

--- a/app/src/main/java/com/example/teacherforboss/presentation/ui/exam/ExamStartActivity.kt
+++ b/app/src/main/java/com/example/teacherforboss/presentation/ui/exam/ExamStartActivity.kt
@@ -1,12 +1,10 @@
 package com.example.teacherforboss.presentation.ui.exam
 
 import android.content.Intent
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.text.Spannable
 import android.text.SpannableString
 import android.text.style.ForegroundColorSpan
-import android.text.style.TextAppearanceSpan
 import androidx.activity.OnBackPressedCallback
 import androidx.core.content.ContextCompat
 import com.example.teacherforboss.R
@@ -27,36 +25,36 @@ class ExamStartActivity : BindingActivity<ActivityExamStartBinding>(R.layout.act
 
     private fun initLayout() {
         binding.examStartWelcomeName.text = SpannableString(
-            getString(R.string.exam_start_title)
+            getString(R.string.exam_start_title),
         ).apply {
             setSpan(
                 ForegroundColorSpan(
                     ContextCompat.getColor(
                         this@ExamStartActivity,
-                        R.color.main_purple_00
-                    )
+                        R.color.main_purple_00,
+                    ),
                 ),
                 SERVICE_START,
                 SERVICE_END,
-                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE,
             )
         }
     }
 
-    private fun addListeners(){
+    private fun addListeners() {
         binding.layoutExamStartBtn.setOnClickListener { navigateToExam() }
         binding.ivExamStartBackBtn.setOnClickListener { navigateToHome() }
     }
 
-    private fun navigateToExam(){
+    private fun navigateToExam() {
         Intent(this, ExamActivity::class.java).apply {
             startActivity(this)
             finish()
         }
     }
 
-    private fun navigateToHome(){
-        Intent(this, MainActivity::class.java).apply{
+    private fun navigateToHome() {
+        Intent(this, MainActivity::class.java).apply {
             startActivity(this)
             finish()
         }

--- a/app/src/main/java/com/example/teacherforboss/presentation/ui/exam/question/ExamSecondFragment.kt
+++ b/app/src/main/java/com/example/teacherforboss/presentation/ui/exam/question/ExamSecondFragment.kt
@@ -44,9 +44,10 @@ class ExamSecondFragment :
                     binding.btnExamSecondFourthAnswer,
                     4,
                 )
+
                 R.id.btn_exam_second_fifth_answer -> setRadioCheckedJob(
                     binding.btnExamSecondFifthAnswer,
-                    5
+                    5,
                 )
             }
         }

--- a/app/src/main/res/layout/activity_exam.xml
+++ b/app/src/main/res/layout/activity_exam.xml
@@ -28,45 +28,45 @@
 
         <TextView
             android:id="@+id/tv_exam_slash"
-            app:layout_constraintTop_toTopOf="parent"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/spacing16"
             android:text="@string/exam_slash"
             android:textAppearance="@style/TextAppearance.TeacherForBoss.Title.SemiBold.18"
-            app:layout_constraintStart_toStartOf="@id/gl_exam_start"
             app:layout_constraintEnd_toEndOf="@id/gl_exam_end"
-            android:layout_marginTop="@dimen/spacing16"/>
+            app:layout_constraintStart_toStartOf="@id/gl_exam_start"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
             android:id="@+id/tv_exam_current_page"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:layout_constraintTop_toTopOf="@id/tv_exam_slash"
-            app:layout_constraintEnd_toStartOf="@id/tv_exam_slash"
+            android:textAppearance="@style/TextAppearance.TeacherForBoss.Title.SemiBold.18"
             app:layout_constraintBottom_toBottomOf="@id/tv_exam_slash"
-            tools:text="1"
-            android:textAppearance="@style/TextAppearance.TeacherForBoss.Title.SemiBold.18"/>
+            app:layout_constraintEnd_toStartOf="@id/tv_exam_slash"
+            app:layout_constraintTop_toTopOf="@id/tv_exam_slash"
+            tools:text="1" />
 
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:layout_constraintStart_toEndOf="@id/tv_exam_slash"
-            app:layout_constraintTop_toTopOf="@id/tv_exam_slash"
-            app:layout_constraintBottom_toBottomOf="@id/tv_exam_slash"
+            android:text="@string/exam_total_question"
             android:textAppearance="@style/TextAppearance.TeacherForBoss.Title.SemiBold.18"
-            android:text="@string/exam_total_question"/>
+            app:layout_constraintBottom_toBottomOf="@id/tv_exam_slash"
+            app:layout_constraintStart_toEndOf="@id/tv_exam_slash"
+            app:layout_constraintTop_toTopOf="@id/tv_exam_slash" />
 
         <TextView
             android:id="@+id/tv_exam_timer"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            tools:text="10:00"
+            android:layout_marginTop="@dimen/spacing16"
             android:layout_marginEnd="2dp"
             android:textAppearance="@style/TextAppearance.TeacherForBoss.Body.Medium.16"
             android:textColor="@color/sub_red"
             app:layout_constraintEnd_toEndOf="@id/gl_exam_end"
             app:layout_constraintTop_toTopOf="@id/tv_exam_slash"
-            android:layout_marginTop="@dimen/spacing16"/>
+            tools:text="10:00" />
 
         <com.skydoves.progressview.ProgressView
             android:id="@+id/progressbar_exam"
@@ -114,11 +114,11 @@
             android:layout_marginBottom="@dimen/spacing30"
             android:backgroundTint="@color/selector_all_btn_background"
             android:enabled="@{viewModel.examBtnEnabled}"
+            android:text="@string/exam_next_btn"
             android:textAppearance="@style/TextAppearance.TeacherForBoss.Body.Medium.16"
             android:textColor="@color/white"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="@id/gl_exam_end"
-            app:layout_constraintStart_toStartOf="@id/gl_exam_start"
-            android:text="@string/exam_next_btn" />
+            app:layout_constraintStart_toStartOf="@id/gl_exam_start" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/activity_exam_start.xml
+++ b/app/src/main/res/layout/activity_exam_start.xml
@@ -37,10 +37,10 @@
             android:layout_width="wrap_content"
             android:layout_height="0dp"
             android:layout_marginTop="@dimen/spacing30"
+            android:gravity="center"
             android:text="@string/exam_start_title"
             android:textAppearance="@style/TextAppearance.TeacherForBoss.Title.SemiBold.20"
             android:textColor="@color/black"
-            android:gravity="center"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/iv_exam_start_welcome_img" />

--- a/app/src/main/res/layout/fragment_exam_first.xml
+++ b/app/src/main/res/layout/fragment_exam_first.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <data>
 
@@ -80,8 +80,8 @@
             android:layout_marginTop="87dp"
             android:paddingVertical="@dimen/spacing3"
             android:text="@string/exam_question1_answer1"
-            app:layout_constraintEnd_toEndOf="parent"
             android:textAppearance="@style/TextAppearance.TeacherForBoss.Body.Regular.16"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/rg_exam"
             app:layout_constraintTop_toBottomOf="@id/tv_exam_first_question" />
 
@@ -92,9 +92,9 @@
             android:layout_marginStart="@dimen/spacing15"
             android:layout_marginTop="@dimen/spacing14"
             android:paddingVertical="@dimen/spacing3"
-            app:layout_constraintEnd_toEndOf="parent"
             android:text="@string/exam_question1_answer2"
             android:textAppearance="@style/TextAppearance.TeacherForBoss.Body.Regular.16"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/rg_exam"
             app:layout_constraintTop_toBottomOf="@id/tv_exam_first_answer" />
 
@@ -103,11 +103,11 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/spacing15"
-            app:layout_constraintEnd_toEndOf="parent"
             android:layout_marginTop="@dimen/spacing14"
             android:paddingVertical="@dimen/spacing3"
             android:text="@string/exam_question1_answer3"
             android:textAppearance="@style/TextAppearance.TeacherForBoss.Body.Regular.16"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/rg_exam"
             app:layout_constraintTop_toBottomOf="@id/tv_exam_second_answer" />
 
@@ -119,8 +119,8 @@
             android:layout_marginTop="@dimen/spacing14"
             android:paddingVertical="@dimen/spacing4"
             android:text="@string/exam_question1_answer4"
-            app:layout_constraintEnd_toEndOf="parent"
             android:textAppearance="@style/TextAppearance.TeacherForBoss.Body.Regular.16"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/rg_exam"
             app:layout_constraintTop_toBottomOf="@id/tv_exam_third_answer" />
 

--- a/app/src/main/res/layout/fragment_exam_second.xml
+++ b/app/src/main/res/layout/fragment_exam_second.xml
@@ -91,8 +91,8 @@
             android:layout_marginTop="87dp"
             android:paddingVertical="@dimen/spacing3"
             android:text="@string/exam_question2_answer1"
-            app:layout_constraintEnd_toEndOf="parent"
             android:textAppearance="@style/TextAppearance.TeacherForBoss.Body.Regular.16"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/rg_exam"
             app:layout_constraintTop_toBottomOf="@id/tv_exam_second_question" />
 
@@ -103,9 +103,9 @@
             android:layout_marginStart="@dimen/spacing15"
             android:layout_marginTop="@dimen/spacing14"
             android:paddingVertical="@dimen/spacing3"
-            app:layout_constraintEnd_toEndOf="parent"
             android:text="@string/exam_question2_answer2"
             android:textAppearance="@style/TextAppearance.TeacherForBoss.Body.Regular.16"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/rg_exam"
             app:layout_constraintTop_toBottomOf="@id/tv_exam_second_first_answer" />
 
@@ -114,11 +114,11 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/spacing15"
-            app:layout_constraintEnd_toEndOf="parent"
             android:layout_marginTop="@dimen/spacing14"
             android:paddingVertical="@dimen/spacing3"
             android:text="@string/exam_question2_answer3"
             android:textAppearance="@style/TextAppearance.TeacherForBoss.Body.Regular.16"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/rg_exam"
             app:layout_constraintTop_toBottomOf="@id/tv_exam_second_second_answer" />
 
@@ -130,8 +130,8 @@
             android:layout_marginTop="@dimen/spacing14"
             android:paddingVertical="@dimen/spacing4"
             android:text="@string/exam_question2_answer4"
-            app:layout_constraintEnd_toEndOf="parent"
             android:textAppearance="@style/TextAppearance.TeacherForBoss.Body.Regular.16"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/rg_exam"
             app:layout_constraintTop_toBottomOf="@id/tv_exam_second_third_answer" />
 
@@ -143,8 +143,8 @@
             android:layout_marginTop="@dimen/spacing14"
             android:paddingVertical="@dimen/spacing4"
             android:text="@string/exam_question2_answer5"
-            app:layout_constraintEnd_toEndOf="parent"
             android:textAppearance="@style/TextAppearance.TeacherForBoss.Body.Regular.16"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/rg_exam"
             app:layout_constraintTop_toBottomOf="@id/tv_exam_second_fourth_answer" />
 

--- a/app/src/main/res/layout/fragment_exam_third.xml
+++ b/app/src/main/res/layout/fragment_exam_third.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <data>
 
@@ -70,8 +70,8 @@
             android:layout_marginTop="87dp"
             android:paddingVertical="@dimen/spacing3"
             android:text="@string/exam_question3_answer1"
-            app:layout_constraintEnd_toEndOf="parent"
             android:textAppearance="@style/TextAppearance.TeacherForBoss.Body.Regular.16"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/rg_exam"
             app:layout_constraintTop_toBottomOf="@id/tv_exam_third_question" />
 
@@ -82,9 +82,9 @@
             android:layout_marginStart="@dimen/spacing15"
             android:layout_marginTop="@dimen/spacing14"
             android:paddingVertical="@dimen/spacing3"
-            app:layout_constraintEnd_toEndOf="parent"
             android:text="@string/exam_question3_answer2"
             android:textAppearance="@style/TextAppearance.TeacherForBoss.Body.Regular.16"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/rg_exam"
             app:layout_constraintTop_toBottomOf="@id/tv_exam_third_first_answer" />
 
@@ -93,11 +93,11 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/spacing15"
-            app:layout_constraintEnd_toEndOf="parent"
             android:layout_marginTop="@dimen/spacing14"
             android:paddingVertical="@dimen/spacing3"
             android:text="@string/exam_question3_answer3"
             android:textAppearance="@style/TextAppearance.TeacherForBoss.Body.Regular.16"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/rg_exam"
             app:layout_constraintTop_toBottomOf="@id/tv_exam_third_second_answer" />
 


### PR DESCRIPTION
## Related issue 🛠
- closed #28 

## Work Description ✏️
- 시험보기 시작 뷰 : Spannable로 '서비스' 글자 보라색으로 변경
- 안드로이드 이전 버튼 기능 추가
    - 시험보기 시작 뷰 : MainActivity로 이동
    - 시험보기 뷰 : < 버튼과 동일하게 작동하도록 구현   
- 전체적인 정렬 적용

## Screenshot 📸
생략

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
냠냠